### PR TITLE
[fix][era][cata]: Compatibility updates with LFGBulletinBoard minimap button

### DIFF
--- a/Compatibility.lua
+++ b/Compatibility.lua
@@ -108,6 +108,13 @@ function DF.Compatibility:TacoTipInspect()
     itemlvl:SetPoint('BOTTOMRIGHT', itemlvltext, 'TOPRIGHT', 0, 2)
 end
 
+function DF.Compatibility:LFGBulletinBoard(func)
+    -- related issues: #235, Vysci/LFG-Bulletin-Board#301
+    local btn = _G['LFGBulletinBoardMinimapButton']
+    if not btn then return end
+    func(btn)
+end
+
 if DF.Era then
     function DF.Compatibility:ClassicCalendarEra()
         -- print('DF.Compatibility:ClassicCalendarEra()')
@@ -124,55 +131,6 @@ if DF.Era then
             -- print('override!')
             CalendarButtonFrame_OnClick(btn)
         end)
-    end
-
-    function DF.Compatibility:LFGBulletinBoard(func)
-        local btn = _G['Lib_GPI_Minimap_LFGBulletinBoard']
-        if not btn then return end
-        func(btn)
-
-        local function newOnUpdate(button)
-            local mx, my = Minimap:GetCenter()
-            local px, py = GetCursorPosition()
-            local w = ((Minimap:GetWidth() / 2) + 5)
-            local scale = Minimap:GetEffectiveScale()
-            px, py = px / scale, py / scale
-            local dx, dy = px - mx, py - my
-            local dist = math.sqrt(dx * dx + dy * dy) / w
-            if button.Lib_GPI_MinimapButton.db.lockDistance then
-                dist = 1
-            else
-                if dist < 1 then
-                    dist = 1
-                elseif dist > 2 then
-                    dist = 2
-                end
-            end
-
-            -- DF
-            dist = 0.93
-
-            button.Lib_GPI_MinimapButton.db.distance = dist
-            button.Lib_GPI_MinimapButton.db.position = math.deg(math.atan2(dy, dx)) % 360
-            button.Lib_GPI_MinimapButton.UpdatePosition()
-        end
-
-        hooksecurefunc(btn, 'SetScript', function(self, script, scriptFunction, ...)
-            --
-            -- print('SetScript', script, scriptFunction, ...)
-
-            if not script == 'OnUpdate' then return end
-
-            if not scriptFunction then return end
-            --  print('SetScript with func')
-
-            if scriptFunction ~= newOnUpdate then
-                btn:SetScript('OnUpdate', newOnUpdate)
-            else
-                -- print('same!')
-            end
-        end)
-        newOnUpdate(btn)
     end
 
     function DF.Compatibility:CharacterStatsClassic()


### PR DESCRIPTION
**Related Issues**:
- #235 

**In this PR**:
Button will now get handled but the `LibDBIcon-1.0` if our users are using it.

Compatibility function now only skins the non `LibDBIcon-1.0` compliant minimap button from LFGBulletinBoard. This allows us (LFGBulletinBoard) to maintain functionality of not having the button anchored to the minimap perimeter.

**Images**
(*Non* LibDBIcon version. Skinned and aligned with other LibDB ones, maintains our addons functionality still)
![WowClassicT_upW4dIajlc](https://github.com/user-attachments/assets/edeee681-fc81-461c-9277-389ff7e89f74)

(LibDBIcon managed version enabled. Your addon will treat it like any other LibDBIcon button)
![WowClassicT_Nw7FsTsoHH](https://github.com/user-attachments/assets/c5a02dad-a4b4-4f6e-9783-40675970b1f4)
  - Note:  A reload is required on our end when toggling LibDBIcon mode for it to actually take effect, so no additional logic required for edge cases there.
 
**Tested On**
- [x] Era & SoD
- [x] Cataclysm
