### PR TITLE
Fix "What's Training?" with UI Module Enabled + Change SpellBook Disabled

### DIFF
--- a/Modules/UI.lua
+++ b/Modules/UI.lua
@@ -339,6 +339,7 @@ function Module:ApplySettings()
 end
 
 function Module:ChangeFrames()
+    local db = Module.db.profile.first
     -- DragonflightUIMixin:UIPanelCloseButton(_G['DragonflightUIConfigFrame'].ClosePanelButton)
 
     -- Dragonflight Config
@@ -446,9 +447,11 @@ function Module:ChangeFrames()
         -- DragonflightUIMixin:ChangeSpellbookEra()
         -- DragonflightUIMixin:SpellbookEraAddTabs()
         -- DragonflightUIMixin:SpellbookEraProfessions()
-        Module:FuncOrWaitframe('WhatsTraining', function()
+        if db.changeSpellBook then 
+            Module:FuncOrWaitframe('WhatsTraining', function()
             DF.Compatibility:WhatsTraining()
-        end)
+            end)
+        end
         --[[ DragonflightUIMixin:ChangeCharacterFrameEra()
         Module:FuncOrWaitframe('Blizzard_EngravingUI', function()
             EngravingFrame:SetPoint('TOPLEFT', CharacterFrame, 'TOPRIGHT', 9, -75)

--- a/Modules/UI.lua
+++ b/Modules/UI.lua
@@ -274,6 +274,9 @@ function Module:ApplySettings()
         if db.changeSpellBook and not Module.SpellBookHooked then
             Module.SpellBookHooked = true
             DragonflightUIMixin:ChangeSpellbookEra()
+            Module:FuncOrWaitframe('WhatsTraining', function()
+                DF.Compatibility:WhatsTraining()
+            end)
         elseif not db.changeSpellBook and Module.SpellBookHooked then
             DF:Print("'Change SpellBook' was deactivated, but SpellBook was already modified, please /reload.")
         end
@@ -339,7 +342,6 @@ function Module:ApplySettings()
 end
 
 function Module:ChangeFrames()
-    local db = Module.db.profile.first
     -- DragonflightUIMixin:UIPanelCloseButton(_G['DragonflightUIConfigFrame'].ClosePanelButton)
 
     -- Dragonflight Config
@@ -446,12 +448,7 @@ function Module:ChangeFrames()
         --
         -- DragonflightUIMixin:ChangeSpellbookEra()
         -- DragonflightUIMixin:SpellbookEraAddTabs()
-        -- DragonflightUIMixin:SpellbookEraProfessions()
-        if db.changeSpellBook then 
-            Module:FuncOrWaitframe('WhatsTraining', function()
-            DF.Compatibility:WhatsTraining()
-            end)
-        end
+        -- DragonflightUIMixin:SpellbookEraProfessions()  
         --[[ DragonflightUIMixin:ChangeCharacterFrameEra()
         Module:FuncOrWaitframe('Blizzard_EngravingUI', function()
             EngravingFrame:SetPoint('TOPLEFT', CharacterFrame, 'TOPRIGHT', 9, -75)


### PR DESCRIPTION
Fix "What's Training?" displaying incorrectly with UI module enabled but change spellbook disabled - I don't think this code is great practice but it seems to work.

Without this PR
![image](https://github.com/user-attachments/assets/79702cca-4b40-4c02-87c2-3c7d7062fa0b)

With this PR
![image](https://github.com/user-attachments/assets/47f9d74b-be67-4ab2-a956-4204a184d9ef)