### PR TITLE
Fix action bars 6–8 running actions twice when `ActionButtonUseKeyDown` is enabled.

### DIFF
--- a/Modules/Actionbar.lua
+++ b/Modules/Actionbar.lua
@@ -1795,7 +1795,7 @@ function Module:SetupActionbarFrames()
                 if bar then
                     for k, v in ipairs(bar.buttonTable) do
                         --
-                        v:RegisterForClicks("AnyUp", "AnyDown")
+                        v:RegisterForClicks("AnyDown")
                     end
                 end
             end
@@ -1843,7 +1843,7 @@ function Module:SetupActionbarFrames()
             btn:Hide()
 
             if useKeydown then
-                btn:RegisterForClicks("AnyUp", "AnyDown")
+                btn:RegisterForClicks("AnyDown")
             else
                 btn:RegisterForClicks("AnyUp")
             end


### PR DESCRIPTION
Since #322 was fixed, when the `ActionButtonUseKeyDown` CVar setting is enabled, action bars 6–8 will run their action on both key down *and* key up, causing the action to be run twice on a normal key press. The default action bars don't behave this way, so I found the problem and fixed it.