### PR TITLE
Fix: ChangeInspectFrame not working when Blizzard_InspectUI isnt loaded yet

### DIFF
--- a/Modules/UI.lua
+++ b/Modules/UI.lua
@@ -149,7 +149,9 @@ function frame:OnEvent(event, arg1, ...)
         if db.changeInspect and not Module.InspectHooked then
             Module.InspectHooked = true
 
-            DragonflightUIMixin:ChangeInspectFrame()
+            Module:FuncOrWaitframe('Blizzard_InspectUI', function ()
+                DragonflightUIMixin:ChangeInspectFrame()
+            end)
 
             if InspectFrame and not InspectFrame.DFTacoTipHooked then
                 --    


### PR DESCRIPTION
If `Blizzard_InspectUI` not loaded, `InspectFrame` is nil, so the function `ChangeInspectFrame` will returned at the function header.