### PR TITLE
Fix spell crit value length too long.

### DIFF
--- a/Mixin/CharacterStatsWrath.mixin.lua
+++ b/Mixin/CharacterStatsWrath.mixin.lua
@@ -755,7 +755,7 @@ function DragonflightUICharacterStatsWrathMixin:AddStatsSpell()
             newTable[1] = {left = SPELL_CRIT_CHANCE .. ' ' .. string.format('%.2f%%', str)}
 
             -- local str = string.format(' %d', dmg);
-            return str, nil, nil, newTable;
+            return string.format('%.2f%%', str), nil, nil, newTable;
         end
     })
 


### PR DESCRIPTION
Fix spell crit value length too long.
Before:
![image](https://github.com/user-attachments/assets/4abf03ad-832a-4185-a88b-5c888234334b)

After:
![image](https://github.com/user-attachments/assets/53346b7b-5565-40c4-bffd-dbe424dd1eea)
