### PR TITLE
fix flyout arrow not update after click sub button

### DIFF
--- a/Mixin/Spellflyout.mixin.lua
+++ b/Mixin/Spellflyout.mixin.lua
@@ -282,6 +282,14 @@ function DragonflightUISpellFlyoutButtonMixin:InitButtons()
             local attributeFrame = control:GetFrameRef("attributeFrame")
             attributeFrame:SetAttribute('update', not attributeFrame:GetAttribute('update'))
         ]])
+
+        btn:HookScript('OnClick', function()
+            --
+            -- print('onclick')
+            local state = self.state;
+            local char = self.stateChar
+            self:UpdateArrow(char.flyoutDirection or '')
+        end)
     end
 
     self.buttonTable = t;


### PR DESCRIPTION
After clicking the button in the flyout, the 'Flyout Arrow' will not recover.
As:
![image](https://github.com/user-attachments/assets/8b66c935-09ea-4d42-a90c-0d3ac94b8a91)
