### PR TITLE
Fix WhatsTraining Wrath 3.4.5 API compat bug

### DIFF
--- a/Compatibility/WhatsTraining.lua
+++ b/Compatibility/WhatsTraining.lua
@@ -5,7 +5,7 @@ function DF.Compatibility:WhatsTraining()
 
     local base = 'Interface\\Addons\\DragonflightUI\\Textures\\UI\\'
 
-    hooksecurefunc("SpellBookFrame_UpdateSkillLineTabs", function()
+    local function SpellBookFrame_UpdateSkillLineTabs_Hook()
         local frame = _G['WhatsTrainingFrame']
         if frame and frame.DFHooked then return end
 
@@ -89,5 +89,10 @@ function DF.Compatibility:WhatsTraining()
         local scroll = _G['WhatsTrainingFrameScrollBar']
         -- scroll:SetPoint('TOPLEFT', frame, 'TOPLEFT', 120, -75)
         -- scroll:SetPoint('BOTTOMRIGHT', frame, 'BOTTOMRIGHT', -65, 81)
-    end)
+    end
+    if SpellBookFrame_UpdateSkillLineTabs then
+        hooksecurefunc("SpellBookFrame_UpdateSkillLineTabs", SpellBookFrame_UpdateSkillLineTabs_Hook)
+    else
+        hooksecurefunc(SpellBookFrame, "UpdateSkillLineTabs", SpellBookFrame_UpdateSkillLineTabs_Hook)
+    end
 end


### PR DESCRIPTION
Classic Wrath for China has been upgrade to 3.4.5(based on MOP Framework), so fix the API/FrameXML compat bug for WhatsTraining at here.