### PR TITLE
Feature: add ability to hide resting icon and glow on PlayerFrame

### DIFF
--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -698,6 +698,10 @@ do
     L["PlayerFrameHideSecondaryResDesc"] = "Hide the secondary ressource, e.g. soul shards."
     L["PlayerFrameHideAlternatePowerBar"] = "Hide Druid Alternate Power Bar"
     L["PlayerFrameHideAlternatePowerBarDesc"] = "Hide the Druid Alternate Power Bar (Mana Bar while Bear/Cat form)."
+    L["PlayerFrameHideRestingGlow"] = "Hide Resting Glow"
+    L["PlayerFrameHideRestingGlowDesc"] = "Hides the resting status glow on the player frame."
+    L["PlayerFrameHideRestingIcon"] = "Hide Resting Icon"
+    L["PlayerFrameHideRestingIconDesc"] = "Hides the resting icon on the player frame."
 
     -- PowerBar_Alt
     L["PowerBarAltName"] = "Player_PowerBarAlt"

--- a/Modules/Unitframe.lua
+++ b/Modules/Unitframe.lua
@@ -403,6 +403,24 @@ local optionsPlayer = {
             order = 11,
             new = false,
             editmode = true
+        },
+        hideRestingGlow = {
+            type = 'toggle',
+            name = L["PlayerFrameHideRestingGlow"],
+            desc = L["PlayerFrameHideRestingGlowDesc"] .. getDefaultStr('hideRestingGlow', 'player'),
+            group = 'headerStyling',
+            order = 12,
+            new = true,
+            editmode = true
+        },
+        hideRestingIcon = {
+            type = 'toggle',
+            name = L["PlayerFrameHideRestingIcon"],
+            desc = L["PlayerFrameHideRestingIconDesc"] .. getDefaultStr('hideRestingIcon', 'player'),
+            group = 'headerStyling',
+            order = 13,
+            new = true,
+            editmode = true
         }
     }
 }
@@ -3481,6 +3499,16 @@ function Module.UpdatePlayerStatus()
         frame.PlayerFrameBackground:SetVertexColor(1.0, 1.0, 1.0, 1.0)
         PlayerStatusTexture:SetAlpha(0)
         PlayerStatusTexture:Hide()
+    end
+
+    if db.hideRestingGlow and IsResting() then
+        PlayerStatusTexture:SetAlpha(0)
+        PlayerStatusTexture:Hide()
+    end
+
+    if db.hideRestingIcon and IsResting() then
+        frame.RestIcon:Hide()
+        frame.RestIconAnimation:Stop()
     end
 end
 


### PR DESCRIPTION
Something I did not implement, but thought of for a potential future improvement is to let the user pause the animation instead of hiding it outright.