### PR TITLE
Bump toc version for wrath

### DIFF
--- a/DragonflightUI.toc
+++ b/DragonflightUI.toc
@@ -1,7 +1,7 @@
-## Interface: 50500, 40402, 30404, 11507
+## Interface: 50500, 40402, 30405, 30404, 11507
 ## Interface-Mists: 50500
 ## Interface-Cata: 40402
-## Interface-Wrath: 30404
+## Interface-Wrath: 30405, 30404
 ## Interface-Classic: 11507
 ## Title: DragonflightUI |cff8080ff@project-version@|r
 ## Notes: Brings the modern retail UI to classic.|n|cffbbbbbbBy Karl-Heinz Schneider|r|n|n|TInterface/Addons/DragonflightUI/Textures/Art/coffee:12:12|t |cff82c5ffbuymeacoffee.com/karlheinzschneider|r


### PR DESCRIPTION
Bump toc version for wrath.
TOC Version of Wrath for China is 30405 (Based on Mop 5.5.0).