### PR TITLE
fix(unitframe): center hit indicators for pet and player unit frame

### DIFF
--- a/Modules/Unitframe/Pet.mixin.lua
+++ b/Modules/Unitframe/Pet.mixin.lua
@@ -430,6 +430,9 @@ function SubModuleMixin:ChangePetFrame()
 
     self.ModuleRef.SubTargetOfTarget:ChangeToTFrame(self, PetFrame)
 
+    PetHitIndicator:ClearAllPoints()
+    PetHitIndicator:SetPoint('CENTER', PetPortrait, 'CENTER', 0, 0)
+
     PetFrame:SetSize(120, 49)
 
     if not self.PetAttackModeTexture then

--- a/Modules/Unitframe/Player.mixin.lua
+++ b/Modules/Unitframe/Player.mixin.lua
@@ -669,6 +669,9 @@ function SubModuleMixin:CreateCustomPortrait()
     PlayerPortrait:SetDrawLayer('BACKGROUND', -1)
     PlayerPortrait:SetSize(57, 57)
 
+    PlayerHitIndicator:ClearAllPoints()
+    PlayerHitIndicator:SetPoint('CENTER', PlayerPortrait, 'CENTER', 0, 0)
+
     -- function PlayerPortrait:fixClassSize(class)
     --     --
     --     -- print('fixClassSize', class)


### PR DESCRIPTION
The unit frame indicators were not aligened correctly when receiving heals or damage.
Fixed for player and pet.
<img width="311" height="136" alt="image" src="https://github.com/user-attachments/assets/abfa3860-abc0-4055-bb57-29d31c24d3bd" />
