### PR TITLE
fix(unitframe): align player status texture for bigger healthbar

### DIFF
--- a/Modules/Unitframe/Player.mixin.lua
+++ b/Modules/Unitframe/Player.mixin.lua
@@ -1019,7 +1019,7 @@ function SubModuleMixin:SetPlayerBiggerHealthbar(bigger)
         PlayerStatusTexture:SetSize(192, 71)
         PlayerStatusTexture:SetTexCoord(0, 192 / 256, 0, 71 / 128)
         PlayerStatusTexture:ClearAllPoints()
-        PlayerStatusTexture:SetPoint('CENTER', PlayerFrame, 'CENTER', 16, 6.05)
+        PlayerStatusTexture:SetPoint('CENTER', PlayerFrame, 'CENTER', 16 - 1, 6.05 + 1)
 
         PlayerFrameHealthBar:SetSize(124, 32)
         PlayerFrameHealthBar:ClearAllPoints()


### PR DESCRIPTION
When choosing a bigger health bar for player unit frame there was missalignment for the status texture.
<img width="664" height="154" alt="image" src="https://github.com/user-attachments/assets/e8996800-a5d4-43ab-b97a-57f747731b24" />
