### PR TITLE
Enable Baganator compatibility for TBC Anniversary

### DIFF
--- a/Compatibility/Baganator.lua
+++ b/Compatibility/Baganator.lua
@@ -238,7 +238,7 @@ end
 
 function DF.Compatibility:BaganatorEquipment()
     -- print('DF.Compatibility:BaganatorEquipment()')
-    if not DF.API.Version.IsClassic or not Syndicator then return end
+    if not DF.API.Version.IsClassic and not DF.API.Version.IsTBC or not Syndicator then return end
 
     local EquipmentManager_UnpackLocation = EquipmentManager_UnpackLocation or
                                                 function(location) -- Use me, I'm here to be used.
@@ -348,7 +348,7 @@ function DF.Compatibility:BaganatorEquipment()
                 for _, locationID in pairs(C_EquipmentSet.GetItemLocations(setID) or {}) do
                     if locationID ~= -1 and locationID ~= 0 and locationID ~= 1 then
                         local player, bank, bags, _, slot, bag
-                        if DF.API.Version.IsClassic then --   if addonTable.Constants.IsClassic then
+                        if DF.API.Version.IsClassic or DF.API.Version.IsTBC then --   if addonTable.Constants.IsClassic then
                             player, bank, bags, slot, bag = EquipmentManager_UnpackLocation(locationID)
                         else
                             player, bank, bags, _, slot, bag = EquipmentManager_UnpackLocation(locationID)

--- a/Modules/Compatibility/Compatibility.lua
+++ b/Modules/Compatibility/Compatibility.lua
@@ -147,7 +147,7 @@ local compatOptions = {
     }
 }
 
-if DF.API.Version.IsClassic then
+if DF.API.Version.IsClassic or DF.API.Version.IsTBC then
     compatOptions.args.baganatorEquipment = {
         type = 'toggle',
         name = L["CompatBaganatorEquipment"],


### PR DESCRIPTION
It works just fine with this, equipmentset for DFUI and Baganator in bags and bank:

<img width="2230" height="1148" alt="image" src="https://github.com/user-attachments/assets/9c1ffddb-c838-4bf8-beb9-e1d75d552ace" />

