### PR TITLE
Truncate german movement speed text.

### DIFF
--- a/DragonflightUI.toc
+++ b/DragonflightUI.toc
@@ -69,6 +69,7 @@ LocalizationData.lua
 Localization\Bindings.lua
 Localization\BlizzardData\Professions.lua
 Localization\enUS.lua
+Localization\deDE.lua
 Localization\esES.lua
 Localization\ruRU.lua
 Localization\zhCN.lua

--- a/Localization/deDE.lua
+++ b/Localization/deDE.lua
@@ -1,0 +1,7 @@
+local DF = LibStub('AceAddon-3.0'):GetAddon('DragonflightUI')
+local L_DE = LibStub("AceLocale-3.0"):NewLocale("DragonflightUI", "deDE")
+
+if not L_DE then return end
+
+-- Characterstatspanel
+L_DE['CharacterStatsMovementSpeed'] = "Bewegungstempo"

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -701,6 +701,7 @@ do
     L['CharacterStatsSpellPen'] = ITEM_MOD_SPELL_PENETRATION_SHORT or "Spell Penetration" -- ITEM_MOD_SPELL_PENETRATION_SHORT
     L['CharacterStatsSpellPenTooltipFormat'] = SPELL_PENETRATION_TOOLTIP or
                                                    "Spell Penetration %d \n(Reduces enemy resistances by %d)."
+    L['CharacterStatsMovementSpeed'] = STAT_MOVEMENT_SPEED
 
     -- ProfessionFrame
     L["ProfessionFrameHasSkillUp"] = TRADESKILL_FILTER_HAS_SKILL_UP or "Has skill up"

--- a/Mixin/CharacterStatsEra.mixin.lua
+++ b/Mixin/CharacterStatsEra.mixin.lua
@@ -1,5 +1,6 @@
 ---@diagnostic disable: redundant-parameter
 local DF = LibStub('AceAddon-3.0'):GetAddon('DragonflightUI')
+local L = LibStub("AceLocale-3.0"):GetLocale("DragonflightUI")
 
 local ATTACK_SPEED_SECONDS = ATTACK_SPEED_SECONDS or 'Attack Speed (seconds)' -- Era
 
@@ -83,7 +84,7 @@ function DragonflightUICharacterStatsEraMixin:AddStatsGeneral()
 
     self:RegisterElement('movement', 'general', {
         order = 3,
-        name = STAT_MOVEMENT_SPEED,
+        name = L['CharacterStatsMovementSpeed'],
         descr = '..',
         func = function()
             local moveTable, currentSpeed = GetMovementTable()

--- a/Mixin/CharacterStatsTbc.mixin.lua
+++ b/Mixin/CharacterStatsTbc.mixin.lua
@@ -1,5 +1,6 @@
 ---@diagnostic disable: redundant-parameter
 local DF = LibStub('AceAddon-3.0'):GetAddon('DragonflightUI')
+local L = LibStub("AceLocale-3.0"):GetLocale("DragonflightUI")
 
 local ATTACK_SPEED_SECONDS = ATTACK_SPEED_SECONDS or 'Attack Speed (seconds)' -- Era
 
@@ -81,7 +82,7 @@ function DragonflightUICharacterStatsTbcMixin:AddStatsGeneral()
 
     self:RegisterElement('movement', 'general', {
         order = 3,
-        name = STAT_MOVEMENT_SPEED,
+        name = L['CharacterStatsMovementSpeed'],
         descr = '..',
         func = function()
             local moveTable, currentSpeed = GetMovementTable()

--- a/Mixin/CharacterStatsWrath.mixin.lua
+++ b/Mixin/CharacterStatsWrath.mixin.lua
@@ -87,7 +87,7 @@ function DragonflightUICharacterStatsWrathMixin:AddStatsGeneral()
 
     self:RegisterElement('movement', 'general', {
         order = 3,
-        name = STAT_MOVEMENT_SPEED,
+        name = L['CharacterStatsMovementSpeed'],
         descr = '..',
         func = function()
             local moveTable, currentSpeed = GetMovementTable()


### PR DESCRIPTION
In the german version, the word "Bewegungsgeschwindigkeit" (english for movement speed) is too long and overlaps with the actual value:
<img width="300" alt="old" src="https://github.com/user-attachments/assets/a7ba1453-9e50-4371-9753-00cf7079b790" />

This commit proposes a separate deDE.lua file for changing it to a shorter version without changing the width of the table itself:
<img width="300" alt="new" src="https://github.com/user-attachments/assets/f135143d-13b1-490f-abf0-ab7d9eaf4618" />

I was also thinking about "Bewegungsgeschw." but that looks a bit off with the colon at the end. But just my personal preference.