### PR TITLE
[TBC] Fix misaligned quest text/background

### DIFF
--- a/DragonflightUI.toc
+++ b/DragonflightUI.toc
@@ -69,6 +69,7 @@ LocalizationData.lua
 Localization\Bindings.lua
 Localization\BlizzardData\Professions.lua
 Localization\enUS.lua
+Localization\deDE.lua
 Localization\esES.lua
 Localization\ruRU.lua
 Localization\zhCN.lua

--- a/Localization/deDE.lua
+++ b/Localization/deDE.lua
@@ -1,0 +1,7 @@
+local DF = LibStub('AceAddon-3.0'):GetAddon('DragonflightUI')
+local L_DE = LibStub("AceLocale-3.0"):NewLocale("DragonflightUI", "deDE")
+
+if not L_DE then return end
+
+-- Characterstatspanel
+L_DE['CharacterStatsMovementSpeed'] = "Bewegungstempo"

--- a/Localization/enUS.lua
+++ b/Localization/enUS.lua
@@ -701,6 +701,7 @@ do
     L['CharacterStatsSpellPen'] = ITEM_MOD_SPELL_PENETRATION_SHORT or "Spell Penetration" -- ITEM_MOD_SPELL_PENETRATION_SHORT
     L['CharacterStatsSpellPenTooltipFormat'] = SPELL_PENETRATION_TOOLTIP or
                                                    "Spell Penetration %d \n(Reduces enemy resistances by %d)."
+    L['CharacterStatsMovementSpeed'] = STAT_MOVEMENT_SPEED
 
     -- ProfessionFrame
     L["ProfessionFrameHasSkillUp"] = TRADESKILL_FILTER_HAS_SKILL_UP or "Has skill up"

--- a/Mixin/CharacterStatsEra.mixin.lua
+++ b/Mixin/CharacterStatsEra.mixin.lua
@@ -1,5 +1,6 @@
 ---@diagnostic disable: redundant-parameter
 local DF = LibStub('AceAddon-3.0'):GetAddon('DragonflightUI')
+local L = LibStub("AceLocale-3.0"):GetLocale("DragonflightUI")
 
 local ATTACK_SPEED_SECONDS = ATTACK_SPEED_SECONDS or 'Attack Speed (seconds)' -- Era
 
@@ -83,7 +84,7 @@ function DragonflightUICharacterStatsEraMixin:AddStatsGeneral()
 
     self:RegisterElement('movement', 'general', {
         order = 3,
-        name = STAT_MOVEMENT_SPEED,
+        name = L['CharacterStatsMovementSpeed'],
         descr = '..',
         func = function()
             local moveTable, currentSpeed = GetMovementTable()

--- a/Mixin/CharacterStatsTbc.mixin.lua
+++ b/Mixin/CharacterStatsTbc.mixin.lua
@@ -1,5 +1,6 @@
 ---@diagnostic disable: redundant-parameter
 local DF = LibStub('AceAddon-3.0'):GetAddon('DragonflightUI')
+local L = LibStub("AceLocale-3.0"):GetLocale("DragonflightUI")
 
 local ATTACK_SPEED_SECONDS = ATTACK_SPEED_SECONDS or 'Attack Speed (seconds)' -- Era
 
@@ -81,7 +82,7 @@ function DragonflightUICharacterStatsTbcMixin:AddStatsGeneral()
 
     self:RegisterElement('movement', 'general', {
         order = 3,
-        name = STAT_MOVEMENT_SPEED,
+        name = L['CharacterStatsMovementSpeed'],
         descr = '..',
         func = function()
             local moveTable, currentSpeed = GetMovementTable()

--- a/Mixin/CharacterStatsWrath.mixin.lua
+++ b/Mixin/CharacterStatsWrath.mixin.lua
@@ -87,7 +87,7 @@ function DragonflightUICharacterStatsWrathMixin:AddStatsGeneral()
 
     self:RegisterElement('movement', 'general', {
         order = 3,
-        name = STAT_MOVEMENT_SPEED,
+        name = L['CharacterStatsMovementSpeed'],
         descr = '..',
         func = function()
             local moveTable, currentSpeed = GetMovementTable()

--- a/Mixin/UI.mixin.lua
+++ b/Mixin/UI.mixin.lua
@@ -2406,7 +2406,11 @@ function DragonflightUIMixin:ChangeQuestFrame()
     end
 
     do
+        greeting:ClearAllPoints()
+        greeting:SetPoint('TOPLEFT')
+
         local scroll = QuestGreetingScrollFrame
+        scroll:ClearAllPoints()
         scroll:SetSize(300, 403)
         scroll:SetPoint('TOPLEFT', greeting, 'TOPLEFT', 8, -65)
     end


### PR DESCRIPTION
When interacting with a quest NPC that offers multiple quests, the quest text in the detail window was shifted to the left. This only occurred for multi-quest NPCs as far as I could research that.

I could only test this on TBC.