### PR TITLE
Fix misaligned quest text/background.

### DIFF
--- a/Mixin/UI.mixin.lua
+++ b/Mixin/UI.mixin.lua
@@ -2406,7 +2406,11 @@ function DragonflightUIMixin:ChangeQuestFrame()
     end
 
     do
+        greeting:ClearAllPoints()
+        greeting:SetPoint('TOPLEFT')
+
         local scroll = QuestGreetingScrollFrame
+        scroll:ClearAllPoints()
         scroll:SetSize(300, 403)
         scroll:SetPoint('TOPLEFT', greeting, 'TOPLEFT', 8, -65)
     end


### PR DESCRIPTION
When interacting with a quest NPC that offers multiple quests, the quest text in the detail window was shifted to the left. This only occurred for multi-quest NPCs as far as I could research that.

I could only test this on TBC.