### PR TITLE
Fix: Profession keybind not working

### DIFF
--- a/Mixin/UI.mixin.lua
+++ b/Mixin/UI.mixin.lua
@@ -3925,6 +3925,8 @@ function DragonflightUIMixin:SpellbookEraProfessions()
     do
         local toggleButton = CreateFrame('BUTTON', 'DragonflightUISpellbookProfessionFrameToggleButton', UIParent,
                                          'SecureActionButtonTemplate')
+        toggleButton:RegisterForClicks('AnyUp', 'AnyDown')
+        toggleButton:SetSize(1, 1)
         toggleButton:SetAttribute('type', 'macro')
         -- toggleButton:SetAttribute('macrotext', "/run print('test')")
         local macroTextDefault = "/click SpellbookMicroButton" .. "\n" ..


### PR DESCRIPTION
The toggle button was missing RegisterForClicks and had no size, preventing the keybind from triggering the click action, which lead to the profession tab not opening at all.