### PR TITLE
Initial base fixes

### DIFF
--- a/Mixin/Castbar.mixin.lua
+++ b/Mixin/Castbar.mixin.lua
@@ -5,6 +5,9 @@ local craftingRef = 'Interface\\Addons\\DragonflightUI\\Textures\\Castbar\\Casti
 local interruptedRef = 'Interface\\Addons\\DragonflightUI\\Textures\\Castbar\\CastingBarInterrupted2'
 local channelRef = 'Interface\\Addons\\DragonflightUI\\Textures\\Castbar\\CastingBarChannel'
 
+-- Add fallback for missing Blizzard constant
+local CASTING_BAR_ALPHA_STEP = CASTING_BAR_ALPHA_STEP or 0.05
+
 local fishingTable = {
     [7620] = APPRENTICE,
     [7731] = JOURNEYMAN,

--- a/Mixin/EditmodePreview.mixin.lua
+++ b/Mixin/EditmodePreview.mixin.lua
@@ -559,9 +559,17 @@ DragonflightUIEditModePreviewPartyFrameMixin = {}
 function DragonflightUIEditModePreviewPartyFrameMixin:OnLoad()
     -- print('~~ DragonflightUIEditModePreviewPartyFrameMixin:OnLoad()')
 
-    local sizeX, sizeY = _G['PartyMemberFrame' .. 1]:GetSize()
-    local gap = 10;
-    self:SetSize(sizeX, sizeY * 4 + 3 * gap)
+    local partyFrame = _G['PartyMemberFrame' .. 1]
+    local gap = 10
+
+    if not partyFrame then
+        -- Fallback if party frames don't exist yet
+        self:SetSize(120, 265)
+    else
+        local sizeX, sizeY = partyFrame:GetSize()
+        local gap = 10;
+        self:SetSize(sizeX, sizeY * 4 + 3 * gap)
+    end
 
     self.LastUpdate = GetTime()
     self.PartyFrames = {}
@@ -631,7 +639,13 @@ function DragonflightUIEditModePreviewPartyFrameMixin:Update()
     self:SetPoint(state.anchor, parent, state.anchorParent, state.x, state.y)
     self:SetScale(state.scale)
 
-    local sizeX, sizeY = _G['PartyMemberFrame' .. 1]:GetSize()
+    local partyFrame = _G['PartyMemberFrame' .. 1]
+    local sizeX, sizeY
+    if partyFrame then
+        sizeX, sizeY = partyFrame:GetSize()
+    else
+        sizeX, sizeY = 120, 53
+    end
 
     if state.orientation == 'vertical' then
         self:SetSize(sizeX, sizeY * 4 + 3 * state.padding)
@@ -660,6 +674,14 @@ function DragonflightUIEditModePreviewPartyFrameMixin:Update()
 end
 
 function DragonflightUIEditModePreviewPartyFrameMixin:UpdateVisibility()
+    if not GetDisplayedAllyFrames then
+        -- Function doesn't exist, show all frames
+        for k, v in ipairs(self.PartyFrames) do
+            v:Show()
+        end
+        return
+    end
+
     if (GetDisplayedAllyFrames() ~= "party") then
         for k, v in ipairs(self.PartyFrames) do
             --           
@@ -696,8 +718,14 @@ Mixin(DragonflightUIEditModePreviewPartyMixin, DragonflightUIEditModePreviewTarg
 function DragonflightUIEditModePreviewPartyMixin:OnLoad()
     -- print('~~~~~~~~~~~~DragonflightUIEditModePreviewPartyMixin:OnLoad()')
 
-    local sizeX, sizeY = _G['PartyMemberFrame' .. 1]:GetSize()
-    self:SetSize(sizeX, sizeY)
+    local partyFrame = _G['PartyMemberFrame' .. 1]
+    if not partyFrame then
+        -- Fallback size if party frames don't exist yet
+        self:SetSize(120, 53)
+    else
+        local sizeX, sizeY = partyFrame:GetSize()
+        self:SetSize(sizeX, sizeY)
+    end
     self:SetupFrame()
     self:SetRandomUnit()
 end
@@ -775,7 +803,7 @@ function DragonflightUIEditModePreviewPartyMixin:SetupFrame()
     -- end
     -- -- self.PortraitExtra:UpdateStyle('worldboss')
 
-    if DF.Wrath then
+    if DF and DF.Wrath then
         local roleIcon = self.TextureFrame:CreateTexture('DragonflightUIPartyFrameRoleIcon')
         roleIcon:SetSize(12, 12)
         roleIcon:SetPoint('TOPRIGHT', self, 'TOPRIGHT', -5, -5)

--- a/Mixin/Micromenu.mixin.lua
+++ b/Mixin/Micromenu.mixin.lua
@@ -22,7 +22,9 @@ function DragonflightUIMicroMenuMixin:OnLoad()
 
     self.OriginalAnchors = {}
     for k, v in ipairs(self.MicroButtons) do
-        self.OriginalAnchors[k] = {v:GetPoint(1)}
+        local point, relativeTo, relativePoint, xOfs, yOfs = v:GetPoint(1)
+        -- Store with explicit nil handling
+        self.OriginalAnchors[k] = {point, relativeTo, relativePoint, xOfs or 0, yOfs or 0}
         v:SetFrameLevel(self:GetFrameLevel() + 1)
     end
 
@@ -125,7 +127,10 @@ function DragonflightUIMicroMenuMixin:BlizzardMicroMenuShow()
             --
         else
             v:ClearAllPoints()
-            v:SetPoint(unpack(self.OriginalAnchors[k]))
+            local anchorData = self.OriginalAnchors[k]
+            if anchorData and anchorData[1] then
+                v:SetPoint(anchorData[1], anchorData[2], anchorData[3], anchorData[4], anchorData[5])
+            end
         end
     end
 end
@@ -153,54 +158,71 @@ function DragonflightUIMicroMenuMixin:UpdateLayout(force)
             v:SetPoint('TOPLEFT', self, 'TOPLEFT', 0, 0)
         else
             v:ClearAllPoints()
-            v:SetPoint(unpack(self.OriginalAnchors[k]))
+            local anchorData = self.OriginalAnchors[k]
+            if anchorData and anchorData[1] then
+                -- Handle the case where relativeTo might be nil or the button itself
+                local point, relativeTo, relativePoint, xOfs, yOfs = anchorData[1], anchorData[2], anchorData[3], anchorData[4], anchorData[5]
+                v:SetPoint(point, relativeTo, relativePoint, xOfs, yOfs)
+            end
         end
     end
 end
 
 function DragonflightUIMicroMenuMixin:UpdateState(state)
     self.State = state
+    -- Validate state before updating
+    if not state or not state.anchorFrame then
+        DF:Debug(self, 'Invalid MicroMenu state')
+        return
+    end
+
     self:Update()
+    self:UpdateStateHandler(state)
 end
 
 function DragonflightUIMicroMenuMixin:Update()
     local state = self.State
     if not state then return end
 
-    if DF.API.Version.IsTBC then state.customAnchorFrame = ''; end
+    self:ClearAllPoints()
 
-    local parent;
-    if DF.Settings.ValidateFrame(state.customAnchorFrame) then
-        parent = _G[state.customAnchorFrame]
-    else
-        parent = _G[state.anchorFrame]
+    -- Add validation for anchor frame
+    local anchorFrameName = state.customAnchorFrame ~= '' and state.customAnchorFrame or state.anchorFrame
+    local parent = _G[anchorFrameName]
+
+    -- Prevent anchoring to itself
+    if not parent or parent == self then
+        parent = UIParent
+        DF:Debug(self, 'MicroMenu: Invalid anchor (self or nil), using UIParent instead:', anchorFrameName)
     end
 
-    self:SetClampedToScreen(true)
-    self:SetScale(state.scale)
-    self:ClearAllPoints()
+    -- If anchor frame doesn't exist yet, retry after a short delay
+    if not parent:IsShown() then
+        C_Timer.After(0.1, function()
+            if self and self.Update then
+                self:Update()
+            end
+        end)
+        parent = UIParent
+    end
+
     self:SetPoint(state.anchor, parent, state.anchorParent, state.x, state.y)
+    self:SetScale(state.scale)
 
     if DF.API.Version.IsTBC then
         local f = _G['MicroMenuContainer']
-        -- print('s', f:GetSize())
-        -- print('->', self:GetSize())
         f:SetScale(state.scale)
-        -- addonTable:OverrideBlizzEditmode(f, state.anchor, parent, state.anchorParent, state.x, state.y)
-        -- addonTable:OverrideBlizzEditmode(f, 'TOPLEFT', self, 'TOPLEFT', 0, 0)
 
         local point, relativeTo, relativePoint, xOfs, yOfs = f:GetPoint(1)
 
-        if not (relativeTo == self) then addonTable:OverrideBlizzEditmode(f, 'TOPLEFT', self, 'TOPLEFT', 0, 0) end
-
-        -- if not self.FirstMoved then
-        --     self.FirstMoved = true;
-        --     self:UpdateTBCPosition()
-        -- end
-    else
+        if not (relativeTo == self) then 
+            addonTable:OverrideBlizzEditmode(f, 'TOPLEFT', self, 'TOPLEFT', 0, 0) 
+        end
     end
 
-    if self.UpdateStateHandler then self:UpdateStateHandler(state) end
+    if self.UpdateStateHandler then 
+        self:UpdateStateHandler(state) 
+    end
 end
 
 function DragonflightUIMicroMenuMixin:UpdateTBCPosition()

--- a/Mixin/Statusbar.mixin.lua
+++ b/Mixin/Statusbar.mixin.lua
@@ -115,7 +115,10 @@ function DragonflightUIXPBarMixin:SetupTooltip()
             GameTooltip:AddLine(' ')
             GameTooltip:AddLine(restedText)
         else
-            ExhaustionToolTipText()
+            -- Check if the function exists before calling (removed in some recent patches)
+            if ExhaustionToolTipText then
+                ExhaustionToolTipText()
+            end
         end
 
         local playerCurrXP = UnitXP('player')
@@ -170,6 +173,9 @@ end
 
 function DragonflightUIXPBarMixin:Update()
     local state = self.state
+
+    -- Check if state exists before proceeding
+    if not state then return end
 
     local showXP = false
     if DF.Wrath then

--- a/Modules/Actionbar/Actionbar.lua
+++ b/Modules/Actionbar/Actionbar.lua
@@ -2601,7 +2601,7 @@ function Module:AddEditMode()
     });
 
     -- totem
-    if DF.Cata then
+    if DF.Cata and MultiCastActionBarFrame then
         EditModeModule:AddEditModeToFrame(MultiCastActionBarFrame)
 
         MultiCastActionBarFrame.DFEditModeSelection:SetGetLabelTextFunction(function()
@@ -2895,6 +2895,11 @@ function Module:ApplySettingsInternal(sub, key)
     elseif sub == 'bags' then
         Module.UpdateBagState(db.bags)
     elseif sub == 'micro' then
+        if db.micro.anchorFrame == 'DragonflightUIMicroMenuBar' then
+            db.micro.anchorFrame = 'UIParent'
+            DF:Debug(self, 'Fixed circular anchor reference in MicroMenu')
+        end
+
         Module.MicroFrame:UpdateState(db.micro)
     elseif sub == 'fps' then
         Module.FPSFrame:SetState(db.fps)
@@ -2960,30 +2965,40 @@ function Module.ChangeActionbar()
 
         Module:ForceMoveBlizzEditModeGhosts()
     else
-        StanceBarLeft:Hide()
-        StanceBarMiddle:Hide()
-        StanceBarRight:Hide()
-
-        hooksecurefunc(StanceBarRight, 'Show', function()
+        if StanceBarLeft then
             StanceBarLeft:Hide()
             StanceBarMiddle:Hide()
             StanceBarRight:Hide()
-        end)
+
+            hooksecurefunc(StanceBarRight, 'Show', function()
+                StanceBarLeft:Hide()
+                StanceBarMiddle:Hide()
+                StanceBarRight:Hide()
+            end)
+        end
 
         MainMenuBar:SetSize(1, 1)
 
-        MainMenuExpBar:Hide()
-        hooksecurefunc(MainMenuExpBar, 'Show', function()
+        if MainMenuExpBar then
             MainMenuExpBar:Hide()
-        end)
-        ReputationWatchBar:Hide()
-        hooksecurefunc(ReputationWatchBar, 'Show', function()
+            hooksecurefunc(MainMenuExpBar, 'Show', function()
+                MainMenuExpBar:Hide()
+            end)
+        end
+
+        if ReputationWatchBar then
             ReputationWatchBar:Hide()
-        end)
-        MainMenuBarMaxLevelBar:Hide()
-        hooksecurefunc(MainMenuBarMaxLevelBar, 'Show', function()
+            hooksecurefunc(ReputationWatchBar, 'Show', function()
+                ReputationWatchBar:Hide()
+            end)
+        end
+
+        if MainMenuBarMaxLevelBar then
             MainMenuBarMaxLevelBar:Hide()
-        end)
+            hooksecurefunc(MainMenuBarMaxLevelBar, 'Show', function()
+                MainMenuBarMaxLevelBar:Hide()
+            end)
+        end
     end
 end
 
@@ -3108,6 +3123,8 @@ end
 
 -- TODO
 function Module.MoveTotem()
+    if not MultiCastActionBarFrame then return end
+
     MultiCastActionBarFrame.ignoreFramePositionManager = true
     Module.Temp.TotemFixing = nil
     hooksecurefunc(MultiCastActionBarFrame, 'SetPoint', function()
@@ -3292,6 +3309,8 @@ function Module.ChangeMicroMenu()
 end
 
 function Module.UpdateTotemState(state)
+    if not MultiCastActionBarFrame then return end
+
     -- print('UpdateTotemState')
     Module.Temp.TotemFixing = true
     -- MultiCastActionBarFrame:SetPoint('BOTTOM', MultiBarBottomRight, 'TOP', 0, 5)

--- a/Modules/Actionbar/ActionbarRange.mixin.lua
+++ b/Modules/Actionbar/ActionbarRange.mixin.lua
@@ -232,11 +232,14 @@ function SubModuleMixin:Setup()
     -- ActionButton_UpdateUsable
     if DF.API.Version.IsTBC then
     else
-        hooksecurefunc('ActionButton_UpdateUsable', function(btn)
-            -- print('ActionButton_UpdateUsable', btn:GetName() or '')
-            if not self.activate then return end
-            self:UpdateRangeAndUsable(btn, btn.checksRange or false, btn.inRange or false);
-        end)
+        -- Check if the function exists before hooking (removed in some recent patches)
+        if ActionButton_UpdateUsable then
+            hooksecurefunc('ActionButton_UpdateUsable', function(btn)
+                -- print('ActionButton_UpdateUsable', btn:GetName() or '')
+                if not self.activate then return end
+                self:UpdateRangeAndUsable(btn, btn.checksRange or false, btn.inRange or false);
+            end)
+        end
     end
 end
 

--- a/Modules/Castbar/Castbar.lua
+++ b/Modules/Castbar/Castbar.lua
@@ -913,10 +913,13 @@ function Module.AddNewCastbar()
 
     if DF.API.Version.IsTBC then
     else
-        hooksecurefunc('Target_Spellbar_AdjustPosition', function(self)
-            -- print('Target_Spellbar_AdjustPosition', self:GetName())
-            if self.DFCastbar then self.DFCastbar:AdjustPosition() end
-        end)
+        -- Check if the function exists before hooking (removed in some recent patches)
+        if Target_Spellbar_AdjustPosition then
+            hooksecurefunc('Target_Spellbar_AdjustPosition', function(self)
+                -- print('Target_Spellbar_AdjustPosition', self:GetName())
+                if self.DFCastbar then self.DFCastbar:AdjustPosition() end
+            end)
+        end
     end
 end
 

--- a/Modules/Minimap/Minimap.lua
+++ b/Modules/Minimap/Minimap.lua
@@ -678,6 +678,10 @@ function Module:ChangeLFG()
     if DF.Wrath then
         Module.LFG = _G['MiniMapLFGFrame']
 
+        if not Module.LFG then
+            return
+        end
+
         -- Module.LFG:SetFrameLevel(10)
         Module.LFG:Raise()
 

--- a/Modules/Minimap/Minimap.mixin.lua
+++ b/Modules/Minimap/Minimap.mixin.lua
@@ -348,7 +348,10 @@ function SubModuleMixin:Setup()
 
     self:SetScript('OnEvent', self.OnEvent);
     self:RegisterEvent('MINIMAP_UPDATE_TRACKING')
-    self:RegisterEvent('MINIMAP_PING')
+    -- MINIMAP_PING event was removed in recent patches
+    if C_EventUtils and C_EventUtils.IsEventValid("MINIMAP_PING") then
+        self:RegisterEvent('MINIMAP_PING')
+    end
 
     local f = self.BaseFrame
     -- state

--- a/Modules/Unitframe/FocusTarget.mixin.lua
+++ b/Modules/Unitframe/FocusTarget.mixin.lua
@@ -43,10 +43,13 @@ end
 function SubModuleMixin:SetupOptions()
     local Module = self.ModuleRef;
     local function getDefaultStr(key, sub, extra)
-        -- return Module:GetDefaultStr(key, sub)
         local value = self.Defaults[key]
-        local defaultFormat = L["SettingsDefaultStringFormat"]
-        return string.format(defaultFormat, (extra or '') .. tostring(value))
+        if value == nil then
+            value = 'N/A'
+        end
+        local defaultFormat = L["SettingsDefaultStringFormat"] or "Default: %s"
+        local prefix = extra or ''
+        return string.format(defaultFormat, prefix .. tostring(value))
     end
 
     local function setDefaultValues()
@@ -118,7 +121,7 @@ function SubModuleMixin:SetupOptions()
             classcolor = {
                 type = 'toggle',
                 name = L["FocusFrameClassColor"],
-                desc = L["FocusFrameClassColorDesc"] .. getDefaultStr('classcolor', 'focusTarget'),
+                desc = L["FocusFrameClassColorDesc"] .. ' ' .. getDefaultStr('classcolor', 'focusTarget', ''),
                 group = 'headerStyling',
                 order = 2,
                 editmode = true
@@ -240,6 +243,34 @@ function SubModuleMixin:SetupOptions()
 end
 
 function SubModuleMixin:Setup()
+
+    if FocusFrameToT then
+        FocusFrameToT.ignoreFramePositionManager = true
+        FocusFrameToT.ignoreInLayout = true
+
+        -- Remove from edit mode management tables immediately
+        if FRAME_POSITIONS then
+            FRAME_POSITIONS["FocusFrameToT"] = nil
+        end
+        if UIPARENT_MANAGED_FRAME_POSITIONS then
+            UIPARENT_MANAGED_FRAME_POSITIONS["FocusFrameToT"] = nil
+        end
+
+        -- Hook SetPoint to prevent any external attempts to reposition
+        if not FocusFrameToT.DFSetPointHooked then
+            FocusFrameToT.DFSetPointHooked = true
+            local originalSetPoint = FocusFrameToT.SetPoint
+            FocusFrameToT.SetPoint = function(self, ...)
+                -- Only allow SetPoint from our addon, not from Blizzard's edit mode
+                local stack = debugstack(2, 1, 0)
+                if stack and stack:find("DragonflightUI") then
+                    originalSetPoint(self, ...)
+                end
+                -- Silently ignore all other SetPoint calls to prevent the warning
+            end
+        end
+    end
+    
     local function setDefaultSubValues(sub)
         self.ModuleRef:SetDefaultSubValues(sub)
     end
@@ -265,6 +296,9 @@ function SubModuleMixin:Setup()
     f:SetScale(1.0)
     f:SetClampedToScreen(true)
     f:SetMovable(true)
+
+    self:ChangeFocusToT()
+    self:ReApplyFocusToT()
 
     if DF.API.Version.IsTBC then
         --
@@ -305,6 +339,7 @@ function SubModuleMixin:Setup()
     });
 end
 
+
 function SubModuleMixin:OnEvent(event, ...)
 end
 
@@ -318,7 +353,10 @@ function SubModuleMixin:Update()
     if not state then return end
 
     local f_orig = FocusFrameToT
+    if not f_orig then return end
+
     local f = _G['DragonflightUIFocusToTFrame']
+    if not f then return end
 
     local parent;
     if DF.Settings.ValidateFrame(state.customAnchorFrame) then
@@ -327,17 +365,32 @@ function SubModuleMixin:Update()
         parent = _G[state.anchorFrame]
     end
 
-    f:SetScale(state.scale)
-    f:ClearAllPoints()
-    f:SetPoint(state.anchor, parent, state.anchorParent, state.x, state.y)
-    -- f:SetUserPlaced(true)
+    if not parent then
+        parent = UIParent
+    end
 
+    -- Completely detach from Blizzard's edit mode system
+    f_orig.ignoreFramePositionManager = true
+
+    -- Break ALL existing connections
+    f_orig:SetMovable(true)
+    f_orig:SetParent(UIParent)
+    f_orig:ClearAllPoints()
+
+    -- Configure container
+    f:SetMovable(true)
+    f:SetParent(UIParent)
+    f:ClearAllPoints()
+    f:SetScale(state.scale)
+    f:SetPoint(state.anchor, parent, state.anchorParent, state.x, state.y)
+
+    -- Re-parent and anchor the original frame to our container
+    f_orig:SetParent(f)
+    f_orig:SetScale(1.0)
     f_orig:ClearAllPoints()
     f_orig:SetPoint('CENTER', f, 'CENTER', 0, 0)
-    f_orig:SetScale(state.scale)
 
-    if DF.API.Version.IsTBC then
-    else
+    if not DF.API.Version.IsTBC then
         f:SetUserPlaced(true)
         f_orig:SetUserPlaced(true)
     end
@@ -345,15 +398,33 @@ function SubModuleMixin:Update()
     f:SetIgnoreParentAlpha(state.fadeOut and true or false)
 
     self:ReApplyFocusToT()
-    UnitFramePortrait_Update(FocusFrameToT)
 
-    self.PreviewFocusTarget:UpdateState(state);
+    if UnitFramePortrait_Update then
+        UnitFramePortrait_Update(FocusFrameToT)
+    end
+
+    if self.PreviewFocusTarget then
+        self.PreviewFocusTarget:UpdateState(state)
+    end
 end
 
 function SubModuleMixin:ChangeFocusToT()
+    local f = _G['DragonflightUIFocusToTFrame']
+
+    -- Break the original anchor connection to prevent circular dependency
+    FocusFrameToT:SetParent(f or UIParent)
     FocusFrameToT:ClearAllPoints()
-    FocusFrameToT:SetPoint('BOTTOMRIGHT', FocusFrame, 'BOTTOMRIGHT', -35 + 27, -10 - 5)
+
+    -- Don't anchor to FocusFrame directly - let Update() handle positioning
+    if not f then
+        -- Fallback only if container doesn't exist yet
+        FocusFrameToT:SetPoint('CENTER', UIParent, 'CENTER', 0, 0)
+    else
+        FocusFrameToT:SetPoint('CENTER', f, 'CENTER', 0, 0)
+    end
+
     FocusFrameToT:SetSize(93 + 27, 45)
+    FocusFrameToT.ignoreFramePositionManager = true
 
     FocusFrameToT.Portrait = FocusFrameToTPortrait;
     FocusFrameToT.Name = FocusFrameToTTextureFrameName;
@@ -369,6 +440,19 @@ function SubModuleMixin:ChangeFocusToT()
 
     FocusFrameToTTextureFrameUnconsciousText:ClearAllPoints()
     FocusFrameToTTextureFrameUnconsciousText:SetPoint('CENTER', FocusFrameToTHealthBar, 'CENTER', 0, 0)
+
+    -- Prevent Blizzard's secure code from repositioning this frame
+    if FocusFrameToT.SetAttribute then
+        FocusFrameToT:SetAttribute("ignoreFramePositionManager", true)
+    end
+
+    -- Remove from Blizzard's edit mode system
+    if FRAME_POSITIONS then
+        FRAME_POSITIONS["FocusFrameToT"] = nil
+    end
+    if UIPARENT_MANAGED_FRAME_POSITIONS then
+        UIPARENT_MANAGED_FRAME_POSITIONS["FocusFrameToT"] = nil
+    end
 
     if not FocusFrameToT.DFRangeHooked then
         FocusFrameToT.DFRangeHooked = true;

--- a/Modules/Unitframe/Party.mixin.lua
+++ b/Modules/Unitframe/Party.mixin.lua
@@ -383,6 +383,7 @@ function SubModuleMixin:Update()
     if DF.API.Version.IsTBC then return end -- TODOTBC
     local state = self.state;
     if not state then return end
+    if not self.PartyMoveFrame then return end -- Exit if PartyMoveFrame doesn't exist
 
     local parent = _G[state.anchorFrame]
     self.PartyMoveFrame:ClearAllPoints();
@@ -434,6 +435,11 @@ function SubModuleMixin:Update()
 end
 
 function SubModuleMixin:ChangePartyFrame()
+    -- Check if party frames exist
+    if not _G['PartyMemberFrame1'] then
+        return
+    end
+
     local PartyMoveFrame = CreateFrame('Frame', 'DragonflightUIPartyMoveFrame', UIParent)
     PartyMoveFrame:SetPoint('CENTER', UIParent, 'CENTER', 0, 0)
     PartyMoveFrame:SetFrameStrata('LOW')
@@ -451,6 +457,10 @@ function SubModuleMixin:ChangePartyFrame()
 
     for i = 1, 4 do
         local pf = _G['PartyMemberFrame' .. i]
+        if not pf then
+            break
+        end
+        
         pf:SetParent(PartyMoveFrame)
         pf:SetSize(120, 53)
         -- pf:ClearAllPoints()
@@ -909,9 +919,11 @@ end
 function SubModuleMixin:AddStateUpdater()
     for i = 1, 4 do
         local pf = _G['PartyMemberFrame' .. i]
-        Mixin(pf, DragonflightUIStateHandlerMixin)
-        pf:InitStateHandler()
-        pf:SetUnit('party' .. i)
+        if pf then
+            Mixin(pf, DragonflightUIStateHandlerMixin)
+            pf:InitStateHandler()
+            pf:SetUnit('party' .. i)
+        end
     end
 end
 

--- a/Modules/Unitframe/Player.TotemFrame.mixin.lua
+++ b/Modules/Unitframe/Player.TotemFrame.mixin.lua
@@ -217,12 +217,17 @@ local base = 'Interface\\Addons\\DragonflightUI\\Textures\\'
 function SubModuleMixin:SkinTotems()
     for i = 1, 4 do
         local totem = _G['TotemFrameTotem' .. i];
+        if not totem then
+            return
+        end
 
         local bg = _G['TotemFrameTotem' .. i .. 'Background'];
-        bg:SetSize(31, 31)
-        bg:SetTexture(base .. 'ui-minimap-background')
-        bg:ClearAllPoints()
-        bg:SetPoint("CENTER", totem, "CENTER")
+        if bg then
+            bg:SetSize(31, 31)
+            bg:SetTexture(base .. 'ui-minimap-background')
+            bg:ClearAllPoints()
+            bg:SetPoint("CENTER", totem, "CENTER")
+        end
 
         local icon = totem.icon
         -- print(icon:GetSize())


### PR DESCRIPTION
# Summary
After a big patch from [`wow-ui-source`](https://github.com/Gethe/wow-ui-source) [patch 1](https://github.com/Gethe/wow-ui-source/commit/6d4fe9dc25ece7871f9bdd1a747e65933d7c9e2d#diff-b96acdd4911c1ebdf98100724d7ecadb71d1cb127f4f9ecc46cd69c74e3afa91) and [patch 2](https://github.com/Gethe/wow-ui-source/commit/edb239d09b39601ece7fc08617eb7443e9ca7088), UI has been a mess, and lots of errors are popping up. This patch adds defensive guards and fallbacks across several DragonflightUI modules to prevent Lua errors when Blizzard frames, events, constants, or helper functions are unavailable in certain client versions or load states. There are still _lots of bugs_, but I got some other parts fixed.

# Fixes
- Added fallbacks for missing Blizzard APIs/constants such as `CASTING_BAR_ALPHA_STEP`, `GetDisplayedAllyFrames`, `ExhaustionToolTipText`, `ActionButton_UpdateUsable`, `Target_Spellbar_AdjustPosition`, and `MINIMAP_PING`.
- Hardened party frame previews and party frame setup when `PartyMemberFrame` objects are not created yet.
- Improved Micro Menu anchoring by validating state, preventing self/circular anchors, restoring original anchors more safely, and falling back to `UIParent`.
- Added guards for optional frames, including `MultiCastActionBarFrame`, `MiniMapLFGFrame`, stance bar pieces, XP/reputation bars, and totem frames.
- Reworked Focus Target-of-Target positioning to detach it from Blizzard edit mode management and reduce unwanted repositioning/circular dependency issues.
- Improved settings/default text handling when localised default strings or values are missing.
